### PR TITLE
fix MergeHash causing Hash exception when .Add same key

### DIFF
--- a/Assets/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
@@ -98,7 +98,7 @@ namespace UniRx
         {
             foreach (HashEntry item in source2)
             {
-                source1.Add(item.Key, item.Value);
+                source1[item.Key] = item.Value;
             }
             return source1;
         }


### PR DESCRIPTION
this is to prevent error on retrying the http request
