### PR TITLE
Fix ObservableWWW progress not reporting 1 when done

### DIFF
--- a/Assets/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
@@ -167,6 +167,18 @@ namespace UniRx
                     }
                     yield return null;
                 }
+                if (reportProgress != null)
+                {
+                    try
+                    {
+                        reportProgress.Report(www.progress);
+                    }
+                    catch (Exception ex)
+                    {
+                        observer.OnError(ex);
+                        yield break;
+                    }
+                }
 
                 if (cancel.IsCancellationRequested) yield break;
 
@@ -201,6 +213,18 @@ namespace UniRx
                         }
                     }
                     yield return null;
+                }
+                if (reportProgress != null)
+                {
+                    try
+                    {
+                        reportProgress.Report(www.progress);
+                    }
+                    catch (Exception ex)
+                    {
+                        observer.OnError(ex);
+                        yield break;
+                    }
                 }
 
                 if (cancel.IsCancellationRequested) yield break;
@@ -237,6 +261,18 @@ namespace UniRx
                     }
                     yield return null;
                 }
+                if (reportProgress != null)
+                {
+                    try
+                    {
+                        reportProgress.Report(www.progress);
+                    }
+                    catch (Exception ex)
+                    {
+                        observer.OnError(ex);
+                        yield break;
+                    }
+                }
 
                 if (cancel.IsCancellationRequested) yield break;
 
@@ -271,6 +307,18 @@ namespace UniRx
                         }
                     }
                     yield return null;
+                }
+                if (reportProgress != null)
+                {
+                    try
+                    {
+                        reportProgress.Report(www.progress);
+                    }
+                    catch (Exception ex)
+                    {
+                        observer.OnError(ex);
+                        yield break;
+                    }
                 }
 
                 if (cancel.IsCancellationRequested) yield break;


### PR DESCRIPTION
When `www.isDone` is true, `www.progress` is set to 1.  The `IProgress` handler was not catching this previously because it was only passed values in the while loop.