### PR TITLE
Prevent warning when Android build.

### DIFF
--- a/Assets/ObjectTest/Clicker.cs
+++ b/Assets/ObjectTest/Clicker.cs
@@ -11,6 +11,10 @@ namespace UniRx.ObjectTest
 
         public event Action OnExited = delegate { };
 
+#if !UNITY_ANDROID
+
+        // Disable OnMouse_ event handlers to make it easy to confirm warning.
+
         void OnMouseDown()
         {
             OnClicked();
@@ -25,5 +29,8 @@ namespace UniRx.ObjectTest
         {
             OnExited();
         }
+
+#endif
+
     }
 }

--- a/Assets/UniRx/Scripts/UnityEngineBridge/ObservableMonoBehaviour.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/ObservableMonoBehaviour.cs
@@ -387,7 +387,7 @@ namespace UniRx
             return onLevelWasLoaded ?? (onLevelWasLoaded = new Subject<int>());
         }
 
-#if !UNITY_IPHONE
+#if !(UNITY_IPHONE || UNITY_ANDROID)
 
         Subject<Unit> onMouseDown;
 

--- a/Assets/UniRx/Scripts/UnityEngineBridge/TypedMonoBehaviour.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/TypedMonoBehaviour.cs
@@ -92,7 +92,7 @@ namespace UniRx
         /// <summary>This function is called after a new level was loaded.</summary>
         public virtual void OnLevelWasLoaded(int level) { }
 
-#if !UNITY_IPHONE
+#if !(UNITY_IPHONE || UNITY_ANDROID)
 
         /// <summary>OnMouseDown is called when the user has pressed the mouse button while over the GUIElement or Collider.</summary>
         public virtual void OnMouseDown() { }


### PR DESCRIPTION
Unity warns that OnMouse_ event handlers are used when
Android build.

Fixes #48 