### PR TITLE
Make DisposableExtensions.AddTo method-chainable

### DIFF
--- a/Assets/UniRx/Scripts/Disposables/DisposableExtensions.cs
+++ b/Assets/UniRx/Scripts/Disposables/DisposableExtensions.cs
@@ -6,7 +6,8 @@ namespace UniRx
     public static partial class DisposableExtensions
     {
         /// <summary>Add disposable(self) to CompositeDisposable(or other ICollection). Return value is self disposable.</summary>
-        public static IDisposable AddTo(this IDisposable disposable, ICollection<IDisposable> container)
+        public static T AddTo<T>(this T disposable, ICollection<IDisposable> container)
+            where T : IDisposable
         {
             if (disposable == null) throw new ArgumentNullException("disposable");
             if (container == null) throw new ArgumentNullException("container");


### PR DESCRIPTION
I made `DisposableExtensions.AddTo` method-chainable because I want to write like the below.

```cs
CompositeDisposable eventResources = new CompositeDisposable();
IsPressed = Observable.EveryUpdate()
    .Select(_ => Input.GetMouseButton(0))
    .ToReactiveProperty()
    .AddTo(eventResources);
```

Could you review it? Thanks.