### PR TITLE
Fix FirstCore call OnNext many times

### DIFF
--- a/Assets/UniRx/Scripts/Observable.Paging.cs
+++ b/Assets/UniRx/Scripts/Observable.Paging.cs
@@ -670,15 +670,21 @@ namespace UniRx
         {
             return Observable.Create<T>(observer =>
             {
+                var isFirst = true;
                 return source.Subscribe(x =>
                 {
-                    observer.OnNext(x);
-                    observer.OnCompleted();
+                    if(isFirst)
+                    {
+                        isFirst = false;
+                        observer.OnNext(x);
+                        observer.OnCompleted();
+                    }
                 }, observer.OnError,
                 () =>
                 {
                     if (useDefault)
                     {
+                        isFirst = false;
                         observer.OnNext(default(T));
                         observer.OnCompleted();
                     }


### PR DESCRIPTION
FirstCore has called OnNext many times.

For example
```
var rp = new ReactiveProperty<int>(0);
rp.First().Subscribe(x =>
    {
        rp.Value = x+1; //Infinite loop
    });
```