### PR TITLE
Improvement ObserveEveryValueChanged

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObserveExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObserveExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using UniRx.Triggers;
 
 #if !UniRxLibrary
 using ObservableUnity = UniRx.Observable;
@@ -13,16 +14,27 @@ namespace UniRx
         /// <summary>
         /// Publish target property when value is changed. If source is destroyed/destructed, publish OnCompleted.
         /// </summary>
-        public static IObservable<TProperty> ObserveEveryValueChanged<TSource, TProperty>(this TSource source, Func<TSource, TProperty> propertySelector, FrameCountType frameCountType = FrameCountType.Update)
+        /// <param name="fastDestroyCheck">If true and target is UnityObject, use destroyed check by additional component. It is faster check for lifecycle but needs initial cost.</param>
+        public static IObservable<TProperty> ObserveEveryValueChanged<TSource, TProperty>(this TSource source, Func<TSource, TProperty> propertySelector, FrameCountType frameCountType = FrameCountType.Update, bool fastDestroyCheck = false)
             where TSource : class
         {
-            return ObserveEveryValueChanged(source, propertySelector, frameCountType, UnityEqualityComparer.GetDefault<TProperty>());
+            return ObserveEveryValueChanged(source, propertySelector, frameCountType, UnityEqualityComparer.GetDefault<TProperty>(), fastDestroyCheck);
         }
 
         /// <summary>
         /// Publish target property when value is changed. If source is destroyed/destructed, publish OnCompleted.
         /// </summary>
         public static IObservable<TProperty> ObserveEveryValueChanged<TSource, TProperty>(this TSource source, Func<TSource, TProperty> propertySelector, FrameCountType frameCountType, IEqualityComparer<TProperty> comparer)
+            where TSource : class
+        {
+            return ObserveEveryValueChanged(source, propertySelector, frameCountType, comparer, false);
+        }
+
+        /// <summary>
+        /// Publish target property when value is changed. If source is destroyed/destructed, publish OnCompleted.
+        /// </summary>
+        /// <param name="fastDestroyCheck">If true and target is UnityObject, use destroyed check by additional component. It is faster check for lifecycle but needs initial cost.</param>
+        public static IObservable<TProperty> ObserveEveryValueChanged<TSource, TProperty>(this TSource source, Func<TSource, TProperty> propertySelector, FrameCountType frameCountType, IEqualityComparer<TProperty> comparer, bool fastDestroyCheck)
             where TSource : class
         {
             if (source == null) return Observable.Empty<TProperty>();
@@ -51,7 +63,7 @@ namespace UniRx
                         }
 
                         observer.OnNext(firstValue);
-                        return PublishUnityObjectValueChanged(unityObject, firstValue, propertySelector, comparer, observer, cancellationToken);
+                        return PublishUnityObjectValueChanged(unityObject, firstValue, propertySelector, comparer, observer, cancellationToken, fastDestroyCheck);
                     }
                     else
                     {
@@ -142,13 +154,71 @@ namespace UniRx
             }
         }
 
-        static IEnumerator PublishUnityObjectValueChanged<TSource, TProperty>(UnityEngine.Object unityObject, TProperty firstValue, Func<TSource, TProperty> propertySelector, IEqualityComparer<TProperty> comparer, IObserver<TProperty> observer, CancellationToken cancellationToken)
+        static IEnumerator PublishUnityObjectValueChanged<TSource, TProperty>(UnityEngine.Object unityObject, TProperty firstValue, Func<TSource, TProperty> propertySelector, IEqualityComparer<TProperty> comparer, IObserver<TProperty> observer, CancellationToken cancellationToken, bool fastDestroyCheck)
         {
             var currentValue = default(TProperty);
             var prevValue = firstValue;
 
             var source = (TSource)(object)unityObject;
 
+            if (fastDestroyCheck)
+            {
+                ObservableDestroyTrigger destroyTrigger = null;
+                {
+                    var gameObject = unityObject as UnityEngine.GameObject;
+                    if (gameObject == null)
+                    {
+                        var comp = unityObject as UnityEngine.Component;
+                        if (comp != null)
+                        {
+                            gameObject = comp.gameObject;
+                        }
+                    }
+
+                    // can't use faster path
+                    if (gameObject == null) goto STANDARD_LOOP;
+
+                    destroyTrigger = GetOrAddDestroyTrigger(gameObject);
+                }
+
+                // fast compare path
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var isDestroyed = destroyTrigger.IsActivated
+                        ? !destroyTrigger.IsCalledOnDestroy
+                        : (unityObject != null);
+
+                    if (isDestroyed)
+                    {
+                        try
+                        {
+                            currentValue = propertySelector(source);
+                        }
+                        catch (Exception ex)
+                        {
+                            observer.OnError(ex);
+                            yield break;
+                        }
+                    }
+                    else
+                    {
+                        observer.OnCompleted();
+                        yield break;
+                    }
+
+                    if (!comparer.Equals(currentValue, prevValue))
+                    {
+                        observer.OnNext(currentValue);
+                        prevValue = currentValue;
+                    }
+
+                    yield return null;
+                }
+
+                yield break;
+            }
+
+            STANDARD_LOOP:
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (unityObject != null)
@@ -177,6 +247,16 @@ namespace UniRx
 
                 yield return null;
             }
+        }
+
+        static ObservableDestroyTrigger GetOrAddDestroyTrigger(UnityEngine.GameObject go)
+        {
+            var dt = go.GetComponent<ObservableDestroyTrigger>();
+            if (dt == null)
+            {
+                dt = go.AddComponent<ObservableDestroyTrigger>();
+            }
+            return dt;
         }
     }
 }

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDestroyTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDestroyTrigger.cs
@@ -15,6 +15,13 @@ namespace UniRx.Triggers
 
         public bool IsActivated { get; private set; }
 
+        /// <summary>
+        /// Check called OnDestroy.
+        /// This property does not guarantees GameObject was destroyed,
+        /// when gameObject is deactive, does not raise OnDestroy.
+        /// </summary>
+        public bool IsCalledOnDestroy { get { return calledDestroy; } }
+
         void Awake()
         {
             IsActivated = true;


### PR DESCRIPTION
Checks UnityObject is destroyted compare by null(`if (unityObject != null)`) is slightly slow.
attach ObservableDestroyTrigger and check `IsCalledOnDestroy` is fast but it cost initial timing.

I've added `ObserverEveryValueChanged(bool fastDestroyCheck)` overload.
Default value is false(same as until now).