### PR TITLE
Add FirstOrEmpty operator

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Observable.Paging.cs
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Paging.cs
@@ -233,21 +233,31 @@ namespace UniRx
 
         public static IObservable<T> First<T>(this IObservable<T> source)
         {
-            return new FirstObservable<T>(source, false);
+            return new FirstObservable<T>(source, publishOnError: true, publishDefaultValue: false);
         }
         public static IObservable<T> First<T>(this IObservable<T> source, Func<T, bool> predicate)
         {
-            return new FirstObservable<T>(source, predicate, false);
+            return new FirstObservable<T>(source, predicate, publishOnError: true, publishDefaultValue: false);
         }
 
         public static IObservable<T> FirstOrDefault<T>(this IObservable<T> source)
         {
-            return new FirstObservable<T>(source, true);
+            return new FirstObservable<T>(source, publishOnError: false, publishDefaultValue: true);
         }
 
         public static IObservable<T> FirstOrDefault<T>(this IObservable<T> source, Func<T, bool> predicate)
         {
-            return new FirstObservable<T>(source, predicate, true);
+            return new FirstObservable<T>(source, predicate, publishOnError: false, publishDefaultValue: true);
+        }
+
+        public static IObservable<T> FirstOrEmpty<T>(this IObservable<T> source)
+        {
+            return new FirstObservable<T>(source, publishOnError: false, publishDefaultValue: false);
+        }
+
+        public static IObservable<T> FirstOrEmpty<T>(this IObservable<T> source, Func<T, bool> predicate)
+        {
+            return new FirstObservable<T>(source, predicate, publishOnError: false, publishDefaultValue: false);
         }
 
         public static IObservable<T> Single<T>(this IObservable<T> source)

--- a/Assets/Plugins/UniRx/Scripts/Operators/First.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/First.cs
@@ -6,22 +6,25 @@ namespace UniRx.Operators
     internal class FirstObservable<T> : OperatorObservableBase<T>
     {
         readonly IObservable<T> source;
-        readonly bool useDefault;
+        readonly bool publishOnError;
+        readonly bool publishDefaultValue;
         readonly Func<T, bool> predicate;
 
-        public FirstObservable(IObservable<T> source, bool useDefault)
+        public FirstObservable(IObservable<T> source, bool publishOnError, bool publishDefaultValue)
             : base(source.IsRequiredSubscribeOnCurrentThread())
         {
             this.source = source;
-            this.useDefault = useDefault;
+            this.publishOnError = publishOnError;
+            this.publishDefaultValue = publishDefaultValue;
         }
 
-        public FirstObservable(IObservable<T> source, Func<T, bool> predicate, bool useDefault)
+        public FirstObservable(IObservable<T> source, Func<T, bool> predicate, bool publishOnError, bool publishDefaultValue)
             : base(source.IsRequiredSubscribeOnCurrentThread())
         {
             this.source = source;
             this.predicate = predicate;
-            this.useDefault = useDefault;
+            this.publishOnError = publishOnError;
+            this.publishDefaultValue = publishDefaultValue;
         }
 
         protected override IDisposable SubscribeCore(IObserver<T> observer, IDisposable cancel)
@@ -67,9 +70,9 @@ namespace UniRx.Operators
 
             public override void OnCompleted()
             {
-                if (parent.useDefault)
+                if (!parent.publishOnError)
                 {
-                    if (notPublished)
+                    if (notPublished && parent.publishDefaultValue)
                     {
                         observer.OnNext(default(T));
                     }
@@ -138,9 +141,9 @@ namespace UniRx.Operators
 
             public override void OnCompleted()
             {
-                if (parent.useDefault)
+                if (!parent.publishOnError)
                 {
-                    if (notPublished)
+                    if (notPublished && parent.publishDefaultValue)
                     {
                         observer.OnNext(default(T));
                     }

--- a/Tests/UniRx.Tests/Observable.PagingTest.cs
+++ b/Tests/UniRx.Tests/Observable.PagingTest.cs
@@ -388,6 +388,74 @@ namespace UniRx.Tests
         }
 
         [TestMethod]
+        public void FirstOrEmpty()
+        {
+            var s = new Subject<int>();
+
+            var l = new List<Notification<int>>();
+            {
+                s.FirstOrEmpty().Materialize().Subscribe(l.Add);
+
+                s.OnNext(10);
+                s.OnError(new Exception());
+
+                l[0].Value.Is(10);
+                l[1].Kind.Is(NotificationKind.OnCompleted);
+            }
+
+            s = new Subject<int>();
+            l.Clear();
+            {
+                s.FirstOrEmpty().Materialize().Subscribe(l.Add);
+
+                s.OnError(new Exception());
+
+                l[0].Kind.Is(NotificationKind.OnError);
+            }
+
+            s = new Subject<int>();
+            l.Clear();
+            {
+                s.FirstOrEmpty().Materialize().Subscribe(l.Add);
+
+                s.OnCompleted();
+
+                l[0].Kind.Is(NotificationKind.OnCompleted);
+            }
+
+            s = new Subject<int>();
+            l.Clear();
+            {
+                s.FirstOrEmpty(x => x % 2 == 0).Materialize().Subscribe(l.Add);
+                s.OnNext(9);
+                s.OnCompleted();
+
+                l[0].Kind.Is(NotificationKind.OnCompleted);
+            }
+
+            s = new Subject<int>();
+            l.Clear();
+            {
+                s.FirstOrEmpty(x => x % 2 == 0).Materialize().Subscribe(l.Add);
+                s.OnNext(9);
+                s.OnNext(10);
+
+                l[0].Value.Is(10);
+                l[1].Kind.Is(NotificationKind.OnCompleted);
+            }
+
+            s = new Subject<int>();
+            l.Clear();
+            {
+                s.FirstOrEmpty(x => x % 2 == 0).Materialize().Subscribe(l.Add);
+                s.OnNext(9);
+                s.OnError(new Exception());
+
+                l[0].Kind.Is(NotificationKind.OnError);
+            }
+        }
+
+        [TestMethod]
         public void Last()
         {
             var s = new Subject<int>();


### PR DESCRIPTION
Added FirstOrEmpty operator.
This operator behaves like to First and FirstOrDefault, but don't publish OnNext and OnError messages when stream is empty.
