### PR TITLE
Add ResetAfter operator

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Observable.Time.cs
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Time.cs
@@ -136,5 +136,20 @@ namespace UniRx
         {
             return new TimeoutObservable<T>(source, dueTime, scheduler);
         }
+
+        public static IObservable<TSource> ResetAfter<TSource>(this IObservable<TSource> source, TSource defaultValue, TimeSpan dueTime, IScheduler scheduler)
+        {
+            return new ResetAfterObservable<TSource>(source, defaultValue, dueTime, scheduler);
+        }
+
+        public static IObservable<TSource> ResetAfter<TSource>(this IObservable<TSource> source, TSource defaultValue, TimeSpan dueTime)
+        {
+            return source.ResetAfter(defaultValue, dueTime, Scheduler.DefaultSchedulers.TimeBasedOperations);
+        }
+
+        public static IObservable<TSource> ResetAfter<TSource>(this IObservable<TSource> source, TimeSpan dueTime)
+        {
+            return source.ResetAfter(default(TSource), dueTime, Scheduler.DefaultSchedulers.TimeBasedOperations);
+        }
     }
 }

--- a/Dlls/UniRx.Library/Operators/ResetAfter.cs
+++ b/Dlls/UniRx.Library/Operators/ResetAfter.cs
@@ -1,0 +1,86 @@
+﻿using System;
+
+namespace UniRx.Operators
+{
+    internal class ResetAfterObservable<T> : OperatorObservableBase<T>
+    {
+        readonly IObservable<T> source;
+        readonly TimeSpan dueTime;
+        readonly IScheduler scheduler;
+        readonly T defaultValue;
+
+        public ResetAfterObservable(IObservable<T> source, T defaultValue, TimeSpan dueTime, IScheduler scheduler)
+            : base(scheduler == Scheduler.CurrentThread || source.IsRequiredSubscribeOnCurrentThread())
+        {
+            this.source = source;
+            this.dueTime = dueTime;
+            this.scheduler = scheduler;
+            this.defaultValue = defaultValue;
+        }
+
+        protected override IDisposable SubscribeCore(IObserver<T> observer, IDisposable cancel)
+        {
+            return new ResetAfter(this, observer, cancel).Run();
+        }
+
+        class ResetAfter : OperatorObserverBase<T, T>
+        {
+            private readonly ResetAfterObservable<T> parent;
+            private readonly object gate = new object();
+            SerialDisposable cancelable;
+
+            public ResetAfter(ResetAfterObservable<T> parent, IObserver<T> observer, IDisposable cancel) : base(observer, cancel)
+            {
+                this.parent = parent;
+            }
+
+            public IDisposable Run()
+            {
+                cancelable = new SerialDisposable();
+                var subscription = parent.source.Subscribe(this);
+
+                return StableCompositeDisposable.Create(cancelable, subscription);
+            }
+
+            private void OnNext()
+            {
+                lock (gate)
+                {
+                    observer.OnNext(parent.defaultValue);
+                }
+            }
+
+            public override void OnNext(T value)
+            {
+                lock (gate)
+                {
+                    observer.OnNext(value);
+
+                    var d = new SingleAssignmentDisposable();
+                    cancelable.Disposable = d;
+                    d.Disposable = parent.scheduler.Schedule(parent.dueTime, OnNext);
+                }
+            }
+
+            public override void OnError(Exception error)
+            {
+                cancelable.Dispose();
+
+                lock (gate)
+                {
+                    try { observer.OnError(error); } finally { Dispose(); }
+                }
+            }
+
+            public override void OnCompleted()
+            {
+                cancelable.Dispose();
+
+                lock (gate)
+                {
+                    try { observer.OnCompleted(); } finally { Dispose(); }
+                }
+            }
+        }
+    }
+}

--- a/Dlls/UniRx.Library/UniRx.Library.csproj
+++ b/Dlls/UniRx.Library/UniRx.Library.csproj
@@ -486,6 +486,7 @@
     <Compile Include="..\..\Assets\Plugins\UniRx\Scripts\UnityEngineBridge\ReactiveProperty.cs">
       <Link>UnityEngineBridge\ReactiveProperty.cs</Link>
     </Compile>
+    <Compile Include="Operators\ResetAfter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/Tests/UniRx.Tests/ResetAfterTest.cs
+++ b/Tests/UniRx.Tests/ResetAfterTest.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UniRx.Tests
+{
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
+    public class ResetAfterTest
+    {
+        [TestMethod]
+        public void ResetAfter()
+        {
+            //should publish default value
+            var results = Observable.Concat(
+                    Observable.Return(1),
+                    Observable.Return(2).Delay(TimeSpan.FromSeconds(0.5)),
+                    Observable.Return(3).Delay(TimeSpan.FromSeconds(1.1))
+                )
+                .ResetAfter(TimeSpan.FromSeconds(1))
+                .Materialize()
+                .ToArrayWait();
+
+            results.Length.Is(5);
+            results[0].Value.Is(1);
+            results[1].Value.Is(2);
+            results[2].Value.Is(0); //default value
+            results[3].Value.Is(3);
+            results[4].Kind.Is(NotificationKind.OnCompleted);
+        }
+
+        [TestMethod]
+        public void ResetAfter2()
+        {
+            //should measure time from the last message
+            var results = Observable.Concat(
+                    Observable.Return(1).Delay(TimeSpan.FromSeconds(0.1)),
+                    Observable.Return(2).Delay(TimeSpan.FromSeconds(0.1)),
+                    Observable.Return(3).Delay(TimeSpan.FromSeconds(1.1)), // after 1 second from previous message
+                    Observable.Return(4).Delay(TimeSpan.FromSeconds(0.1))
+                )
+                .ResetAfter(TimeSpan.FromSeconds(1))
+                .Materialize()
+                .ToArrayWait();
+
+            results.Length.Is(6);
+            results[0].Value.Is(1);
+            results[1].Value.Is(2);
+            results[2].Value.Is(0); //default value
+            results[3].Value.Is(3);
+            results[4].Value.Is(4);
+            results[5].Kind.Is(NotificationKind.OnCompleted);
+        }
+
+
+        [TestMethod]
+        public void ResetAfter3()
+        {
+            //should publish default value even if last message is the same as default value 
+            var results = Observable.Concat(
+                    Observable.Return(0),
+                    Observable.Return(5).Delay(TimeSpan.FromSeconds(1.5))
+                )
+                .ResetAfter(TimeSpan.FromSeconds(1))
+                .Materialize()
+                .ToArrayWait();
+
+            results.Length.Is(4);
+            results[0].Value.Is(0);
+            results[1].Value.Is(0);//default value
+            results[2].Value.Is(5);
+            results[3].Kind.Is(NotificationKind.OnCompleted);
+        }
+
+        [TestMethod]
+        public void ResetAfter4()
+        {
+            //should be able to set any value as default
+            var results = Observable.Concat(
+                    Observable.Return("first"),
+                    Observable.Return("second").Delay(TimeSpan.FromSeconds(1.5))
+                )
+                .ResetAfter("default", TimeSpan.FromSeconds(1))
+                .Materialize()
+                .ToArrayWait();
+
+            results.Length.Is(4);
+            results[0].Value.Is("first");
+            results[1].Value.Is("default");//default value
+            results[2].Value.Is("second");
+            results[3].Kind.Is(NotificationKind.OnCompleted);
+        }
+
+        [TestMethod]
+        public void ResetAfter5()
+        {
+            //should publish OnCompleted immediately when parent observer is finished
+            var results = Observable.Return(1)
+                .ResetAfter(TimeSpan.FromSeconds(1))
+                .Materialize()
+                .ToArrayWait();
+
+            results.Length.Is(2);
+            results[0].Value.Is(1);
+            results[1].Kind.Is(NotificationKind.OnCompleted);
+        }
+
+
+        [TestMethod]
+        public void ResetAfter6()
+        {
+            //should publish OnError immediately
+            var results = Observable.Return(1)
+                .Concat(Observable.Throw<int>(new Exception("error occurred.")))
+                .ResetAfter(TimeSpan.FromSeconds(1))
+                .Materialize()
+                .ToArrayWait();
+
+            results.Length.Is(2);
+            results[0].Value.Is(1);
+            results[1].Kind.Is(NotificationKind.OnError);
+        }
+    }
+}

--- a/Tests/UniRx.Tests/UniRx.Tests.csproj
+++ b/Tests/UniRx.Tests/UniRx.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="MicroCoroutineTest.cs" />
     <Compile Include="ReactivePropertyTest.cs" />
     <Compile Include="ContinueWithTest.cs" />
+    <Compile Include="ResetAfterTest.cs" />
     <Compile Include="SelectWhereOptimizeTest.cs" />
     <Compile Include="Tools\ChainingAssertion.Unity.cs" />
     <Compile Include="Tools\Init.cs" />


### PR DESCRIPTION
I added `ResetAfter` operator.

This operator will publish "default value" when the certain time passes from last message. 

```csharp
public class ResetAfterSample : MonoBehaviour
{
    [SerializeField]
    private IntReactiveProperty playerHealth = new IntReactiveProperty(10);

    private ReactiveProperty<bool> canControlPlayer;

    void Start()
    {
        //if player damaged, disable player controlling for 1 second.
        canControlPlayer = playerHealth
            .Pairwise()
            .Where(x => x.Previous > x.Current)
            .Select(_ => false)
            .ResetAfter(true, TimeSpan.FromSeconds(1))
            .ToReactiveProperty();

        this.UpdateAsObservable()
            .Where(_ => canControlPlayer.Value)
            .Subscribe(_ =>
            {
                //move action
            });
    }

    public void ApplyDamage()
    {
        playerHealth.Value--;
    }
}
```