### PR TITLE
keep stacktrace when throws an exception

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs
@@ -99,7 +99,7 @@ namespace UniRx.InternalUtil
 
         public void OnError(Exception error)
         {
-            throw error;
+            throw new Exception(null, error);
         }
 
         public void OnNext(T value)

--- a/Assets/Plugins/UniRx/Scripts/Notification.cs
+++ b/Assets/Plugins/UniRx/Scripts/Notification.cs
@@ -270,7 +270,7 @@ namespace UniRx
             /// <summary>
             /// Throws the exception.
             /// </summary>
-            public override T Value { get { throw exception; } }
+            public override T Value { get { throw new Exception(null, exception); } }
 
             /// <summary>
             /// Returns the exception.

--- a/Assets/Plugins/UniRx/Scripts/Observer.cs
+++ b/Assets/Plugins/UniRx/Scripts/Observer.cs
@@ -492,7 +492,7 @@ namespace UniRx
     internal static class Stubs
     {
         public static readonly Action Nop = () => { };
-        public static readonly Action<Exception> Throw = ex => { throw ex; };
+        public static readonly Action<Exception> Throw = ex => { throw new Exception(null, ex); };
 
         // marker for CatchIgnore and Catch avoid iOS AOT problem.
         public static IObservable<TSource> CatchIgnore<TSource>(Exception ex)
@@ -505,19 +505,19 @@ namespace UniRx
     {
         public static readonly Action<T> Ignore = (T t) => { };
         public static readonly Func<T, T> Identity = (T t) => t;
-        public static readonly Action<Exception, T> Throw = (ex, _) => { throw ex; };
+        public static readonly Action<Exception, T> Throw = (ex, _) => { throw new Exception(null, ex); };
     }
 
     internal static class Stubs<T1, T2>
     {
         public static readonly Action<T1, T2> Ignore = (x, y) => { };
-        public static readonly Action<Exception, T1, T2> Throw = (ex, _, __) => { throw ex; };
+        public static readonly Action<Exception, T1, T2> Throw = (ex, _, __) => { throw new Exception(null, ex); };
     }
 
 
     internal static class Stubs<T1, T2, T3>
     {
         public static readonly Action<T1, T2, T3> Ignore = (x, y, z) => { };
-        public static readonly Action<Exception, T1, T2, T3> Throw = (ex, _, __, ___) => { throw ex; };
+        public static readonly Action<Exception, T1, T2, T3> Throw = (ex, _, __, ___) => { throw new Exception(null, ex); };
     }
 }

--- a/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
@@ -36,7 +36,7 @@ namespace UniRx.Operators
                 }
             }
 
-            if (ex != null) throw ex;
+            if (ex != null) throw new Exception(null, ex);
             if (!seenValue) throw new InvalidOperationException("No Elements.");
 
             return value;

--- a/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
@@ -29,7 +29,7 @@ namespace UniRx
             {
                 ThrowIfDisposed();
                 if (!isStopped) throw new InvalidOperationException("AsyncSubject is not completed yet");
-                if (lastError != null) throw lastError;
+                if (lastError != null) throw new Exception(null, lastError);
                 return lastValue;
             }
         }
@@ -315,7 +315,7 @@ namespace UniRx
 
             if (lastError != null)
             {
-                throw lastError;
+                throw new Exception(null, lastError);
             }
 
             if (!hasValue)

--- a/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
@@ -23,7 +23,7 @@ namespace UniRx
             get
             {
                 ThrowIfDisposed();
-                if (lastError != null) throw lastError;
+                if (lastError != null) throw new Exception(null, lastError);
                 return lastValue;
             }
         }

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
@@ -156,7 +156,7 @@ namespace UniRx
             {
                 if (reThrowOnError && HasError)
                 {
-                    throw Error;
+                    throw new Exception(null, Error);
                 }
 
                 return false;
@@ -1147,7 +1147,7 @@ namespace UniRx
         internal static class Stubs
         {
             public static readonly Action Nop = () => { };
-            public static readonly Action<Exception> Throw = ex => { throw ex; };
+            public static readonly Action<Exception> Throw = ex => { throw new Exception(null, ex); };
 
             // Stubs<T>.Ignore can't avoid iOS AOT problem.
             public static void Ignore<T>(T t)


### PR DESCRIPTION
Resolve #247 

`throw ex;` will lose stack trace from where the exception is newed.
Instead, we can treat `ex` as an `InnerException` by `throw new Exception(null, ex);` to keep stack trace.
I grepped the source with  `grep 'throw [^n]'` and made this PR.

reference(Japanese): http://ufcpp.net/study/csharp/misc_stacktrace.html