### PR TITLE
Use ExceptionDispatchInfo.Capture().Throw() for .NET 4.6

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using System.Collections.Generic;
 using System.Text;
 
@@ -99,6 +100,9 @@ namespace UniRx.InternalUtil
 
         public void OnError(Exception error)
         {
+#if NET_4_6
+            ExceptionDispatchInfo.Capture(error).Throw();
+#endif
             throw error;
         }
 

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs
@@ -1,7 +1,10 @@
-﻿using System;
-using System.Runtime.ExceptionServices;
+using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET_4_6
+using System.Runtime.ExceptionServices;
+#endif
 
 namespace UniRx.InternalUtil
 {

--- a/Assets/Plugins/UniRx/Scripts/Observer.cs
+++ b/Assets/Plugins/UniRx/Scripts/Observer.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Threading;
+using System.Runtime.ExceptionServices;
 
 namespace UniRx
 {
@@ -492,7 +493,13 @@ namespace UniRx
     internal static class Stubs
     {
         public static readonly Action Nop = () => { };
-        public static readonly Action<Exception> Throw = ex => { throw ex; };
+        public static readonly Action<Exception> Throw = ex =>
+        {
+#if NET_4_6
+            ExceptionDispatchInfo.Capture(ex).Throw();
+#endif
+            throw ex;
+        };
 
         // marker for CatchIgnore and Catch avoid iOS AOT problem.
         public static IObservable<TSource> CatchIgnore<TSource>(Exception ex)
@@ -505,19 +512,37 @@ namespace UniRx
     {
         public static readonly Action<T> Ignore = (T t) => { };
         public static readonly Func<T, T> Identity = (T t) => t;
-        public static readonly Action<Exception, T> Throw = (ex, _) => { throw ex; };
+        public static readonly Action<Exception, T> Throw = (ex, _) =>
+        {
+#if NET_4_6
+            ExceptionDispatchInfo.Capture(ex).Throw();
+#endif
+            throw ex;
+        };
     }
 
     internal static class Stubs<T1, T2>
     {
         public static readonly Action<T1, T2> Ignore = (x, y) => { };
-        public static readonly Action<Exception, T1, T2> Throw = (ex, _, __) => { throw ex; };
+        public static readonly Action<Exception, T1, T2> Throw = (ex, _, __) =>
+        {
+#if NET_4_6
+            ExceptionDispatchInfo.Capture(ex).Throw();
+#endif
+            throw ex;
+        };
     }
 
 
     internal static class Stubs<T1, T2, T3>
     {
         public static readonly Action<T1, T2, T3> Ignore = (x, y, z) => { };
-        public static readonly Action<Exception, T1, T2, T3> Throw = (ex, _, __, ___) => { throw ex; };
+        public static readonly Action<Exception, T1, T2, T3> Throw = (ex, _, __, ___) =>
+        {
+#if NET_4_6
+            ExceptionDispatchInfo.Capture(ex).Throw();
+#endif
+            throw ex;
+        };
     }
 }

--- a/Assets/Plugins/UniRx/Scripts/Observer.cs
+++ b/Assets/Plugins/UniRx/Scripts/Observer.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Threading;
+
+#if NET_4_6
 using System.Runtime.ExceptionServices;
+#endif
 
 namespace UniRx
 {

--- a/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Runtime.ExceptionServices;
 
 namespace UniRx.Operators
 {
@@ -36,7 +37,13 @@ namespace UniRx.Operators
                 }
             }
 
-            if (ex != null) throw ex;
+            if (ex != null)
+            {
+#if NET_4_6
+                ExceptionDispatchInfo.Capture(ex).Throw();
+#endif
+                throw ex;
+            }
             if (!seenValue) throw new InvalidOperationException("No Elements.");
 
             return value;

--- a/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
@@ -1,5 +1,8 @@
 using System;
+
+#if NET_4_6
 using System.Runtime.ExceptionServices;
+#endif
 
 namespace UniRx.Operators
 {

--- a/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UniRx.InternalUtil;
+using System.Runtime.ExceptionServices;
 
 #if (NET_4_6)
 using System.Runtime.CompilerServices;
@@ -29,7 +30,13 @@ namespace UniRx
             {
                 ThrowIfDisposed();
                 if (!isStopped) throw new InvalidOperationException("AsyncSubject is not completed yet");
-                if (lastError != null) throw lastError;
+                if (lastError != null)
+                {
+#if NET_4_6
+                    ExceptionDispatchInfo.Capture(lastError).Throw();
+#endif
+                    throw lastError;
+                }
                 return lastValue;
             }
         }
@@ -315,6 +322,9 @@ namespace UniRx
 
             if (lastError != null)
             {
+#if NET_4_6
+                ExceptionDispatchInfo.Capture(lastError).Throw();
+#endif
                 throw lastError;
             }
 

--- a/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using UniRx.InternalUtil;
-using System.Runtime.ExceptionServices;
 
 #if (NET_4_6)
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Runtime.ExceptionServices;
 #endif
 
 namespace UniRx

--- a/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
@@ -1,6 +1,9 @@
 using System;
 using UniRx.InternalUtil;
+
+#if NET_4_6
 using System.Runtime.ExceptionServices;
+#endif
 
 namespace UniRx
 {

--- a/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using UniRx.InternalUtil;
+using System.Runtime.ExceptionServices;
 
 namespace UniRx
 {
@@ -23,7 +24,13 @@ namespace UniRx
             get
             {
                 ThrowIfDisposed();
-                if (lastError != null) throw lastError;
+                if (lastError != null)
+                {
+#if NET_4_6
+                    ExceptionDispatchInfo.Capture(lastError).Throw();
+#endif
+                    throw lastError;
+                }
                 return lastValue;
             }
         }

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
@@ -8,7 +8,10 @@ using System.Collections.Generic;
 using UniRx.Triggers;
 using UnityEngine;
 using System.Threading;
+
+#if NET_4_6
 using System.Runtime.ExceptionServices;
+#endif
 
 #if !UniRxLibrary
 using SchedulerUnity = UniRx.Scheduler;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using UniRx.Triggers;
 using UnityEngine;
 using System.Threading;
+using System.Runtime.ExceptionServices;
 
 #if !UniRxLibrary
 using SchedulerUnity = UniRx.Scheduler;
@@ -156,6 +157,9 @@ namespace UniRx
             {
                 if (reThrowOnError && HasError)
                 {
+#if NET_4_6
+                    ExceptionDispatchInfo.Capture(Error).Throw();
+#endif
                     throw Error;
                 }
 
@@ -1147,7 +1151,13 @@ namespace UniRx
         internal static class Stubs
         {
             public static readonly Action Nop = () => { };
-            public static readonly Action<Exception> Throw = ex => { throw ex; };
+            public static readonly Action<Exception> Throw = ex =>
+            {
+#if NET_4_6
+                ExceptionDispatchInfo.Capture(ex).Throw();
+#endif
+                throw ex;
+            };
 
             // Stubs<T>.Ignore can't avoid iOS AOT problem.
             public static void Ignore<T>(T t)


### PR DESCRIPTION
This will preserve the callstack of the original exception in addition
to the callstack of where the exception is rethrown. This will help
track down where exceptions come from.

Related: https://github.com/neuecc/UniRx/issues/247