### PR TITLE
Change "Sample" operator behavior.

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Operators/Sample.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Sample.cs
@@ -201,6 +201,18 @@ namespace UniRx.Operators
 
                 public void OnCompleted()
                 {
+                    lock (parent.gate)
+                    {
+                        if (parent.isUpdated)
+                        {
+                            parent.isUpdated = false;
+                            parent.observer.OnNext(parent.latestValue);
+                        }
+                        if (parent.isCompleted)
+                        {
+                            try { parent.observer.OnCompleted(); } finally { parent.Dispose(); }
+                        }
+                    }
                 }
 
                 public void OnError(Exception error)


### PR DESCRIPTION
Change "Sample" operator with Observable behavior .
When intervalSource publish OnCompleted, it behaves in the same way as Rx.NET.

https://github.com/Reactive-Extensions/Rx.NET/blob/develop/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs