### PR TITLE
Added ReactiveProperty.HasValueNotNull which returns true iff canPubl…

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveProperty.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveProperty.cs
@@ -100,6 +100,14 @@ namespace UniRx
                 return canPublishValueOnSubscribe;
             }
         }
+		
+		public bool HasValueNotNull
+        {
+            get
+            {
+                return canPublishValueOnSubscribe && value != null;
+            }
+        }
 
         public ReactiveProperty()
             : this(default(T))


### PR DESCRIPTION
Added ReactiveProperty.HasValueNotNull which returns true iff canPublishValueOnSubscribe && value != null.

I thought this might be a minor but very handy addition to ReactiveProperties with nullable T. I've run into many cases where null is a valid value for the ReactiveProperty and I've had to manually check for null every time before I wanted to access the actual value.