### PR TITLE
Add notifyCurrentCount option to ReactiveDictionary.ObserveCountChanged

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveDictionary.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveDictionary.cs
@@ -100,7 +100,7 @@ namespace UniRx
         bool TryGetValue(TKey key, out TValue value);
 
         IObservable<DictionaryAddEvent<TKey, TValue>> ObserveAdd();
-        IObservable<int> ObserveCountChanged();
+        IObservable<int> ObserveCountChanged(bool notifyCurrentCount = false);
         IObservable<DictionaryRemoveEvent<TKey, TValue>> ObserveRemove();
         IObservable<DictionaryReplaceEvent<TKey, TValue>> ObserveReplace();
         IObservable<Unit> ObserveReset();
@@ -290,10 +290,19 @@ namespace UniRx
 
         [NonSerialized]
         Subject<int> countChanged = null;
-        public IObservable<int> ObserveCountChanged()
+        public IObservable<int> ObserveCountChanged(bool notifyCurrentCount = false)
         {
             if (isDisposed) return Observable.Empty<int>();
-            return countChanged ?? (countChanged = new Subject<int>());
+
+            var subject = countChanged ?? (countChanged = new Subject<int>());
+            if (notifyCurrentCount)
+            {
+                return subject.StartWith(() => this.Count);
+            }
+            else
+            {
+                return subject;
+            }
         }
 
         [NonSerialized]


### PR DESCRIPTION
ReactiveCollection.ObserveCountChanged has a option : notifyCurrentCount, but ReactiveDictionary doesn't have.
There is no problem to imprement this except that Its type changes, which doesn't matter in most cases.