### PR TITLE
Fixed case where AsyncSubject.OnCompleted discards outObserver.OnError.

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
@@ -61,14 +61,21 @@ namespace UniRx
                 hv = hasValue;
             }
 
-            if (hv)
+            try
             {
-                old.OnNext(v);
-                old.OnCompleted();
+                if (hv)
+                {
+                    old.OnNext(v);
+                    old.OnCompleted();
+                }
+                else
+                {
+                    old.OnCompleted();
+                }                
             }
-            else
+            catch (Exception ex)
             {
-                old.OnCompleted();
+                old.OnError(ex);
             }
         }
 


### PR DESCRIPTION
Example.
```csharp
void Start()
{
    TestAsync().ToObservable()
        .Subscribe(_ =>
        {
            throw new Exception("Expected output log onError.");
        }, 
        ex =>
        {
            // Do not reach
            Debug.LogError(ex);
        });
}

async UniTask<Unit> TestAsync()
{
    await UniTask.DelayFrame(5);
    return Unit.Default;
}
```

1. UniTask.ToObservable call Fire(AsyncSubject<T>, UniTask<T>).
2. UniTaskObbservableExtensions.Fire call AsyncSubject.OnNext and OnCompleted in try-catch scope.
3. Caught exception and called AsyncSubject.OnError.
4. AsyncSubject.OnError returns without doing anything because isStopped flag is already set to true.

```csharp
// UniTaskObservableExtensions.cs
static async UniTaskVoid Fire<T>(AsyncSubject<T> subject, UniTask<T> task)
{
    try
    {
        var value = await task;
        subject.OnNext(value);
        // 2-1 thrown exception
        subject.OnCompleted();
    }
    catch (Exception ex)
    {
        // 3-1 caught exception and called OnError
        subject.OnError(ex);
    }
}
```

```csharp
// AsyncSubject.cs
public void OnCompleted()
{
    IObserver<T> old;
    T v;
    bool hv;
    lock (observerLock)
    {
        ThrowIfDisposed();
        // 2-2 Set isStopped flag to true.
        if (isStopped) return;

        old = outObserver;
        outObserver = EmptyObserver<T>.Instance;
        isStopped = true;
        v = lastValue;
        hv = hasValue;
    }

    if (hv)
    {
        // 2-3 thrown exception.
        old.OnNext(v);
        old.OnCompleted();
    }
    else
    {
        old.OnCompleted();
    }
}
```

```csharp 
// AsyncSubject.cs
public void OnError(Exception error)
{
    if (error == null) throw new ArgumentNullException("error");

    IObserver<T> old;
    lock (observerLock)
    {
        ThrowIfDisposed();
        // 3-1 isStopped==true then return.
        if (isStopped) return;

        old = outObserver;
        outObserver = EmptyObserver<T>.Instance;
        isStopped = true;
        lastError = error;
    }

    old.OnError(error);
}
```