### PR TITLE
Fixed exception happening when quitting on MainThreadDispatcher

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -445,6 +445,13 @@ namespace UniRx
                 // Don't try to add a GameObject when the scene is not playing. Only valid in the Editor, EditorView.
                 if (!ScenePlaybackDetector.IsPlaying) return;
 #endif
+                if (isQuitting)
+                {
+                    // don't create new instance after quitting
+                    // avoid "Some objects were not cleaned up when closing the scene find target" error.
+                    return;
+                }
+	            
                 MainThreadDispatcher dispatcher = null;
 
                 try
@@ -457,13 +464,6 @@ namespace UniRx
                     var ex = new Exception("UniRx requires a MainThreadDispatcher component created on the main thread. Make sure it is added to the scene before calling UniRx from a worker thread.");
                     UnityEngine.Debug.LogException(ex);
                     throw ex;
-                }
-
-                if (isQuitting)
-                {
-                    // don't create new instance after quitting
-                    // avoid "Some objects were not cleaned up when closing the scene find target" error.
-                    return;
                 }
 
                 if (dispatcher == null)


### PR DESCRIPTION
We have noticed exceptions happening when the app is being shut down. `MainThreadDispatcher` calls `FindObjectOfType` from a background thread because the existing instance has already been destroyed by Unity. This is handled somewhat gracefully in the Editor:
![screen shot 2018-09-20 at 13 30 59](https://user-images.githubusercontent.com/431167/46148174-294f7900-c270-11e8-9e28-8db98801b3f8.png)


However, on iOS (and most likely all platforms that use IL2CPP) this actually results in a crash:
```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x00000000000001f8

Triggered by Thread:  14

Thread 0 name:
Thread 0:
[...]
8   yousician                     	0x00000001051c79c4 PlayerCleanup(bool) + 80 (Player.cpp:613)
9   yousician                     	0x0000000104ff5568 UnityCleanup + 84 (LibEntryPoint.mm:215)
10  yousician                     	0x000000010275389c -[UnityAppController applicationWillTerminate:] + 24 (UnityAppController.mm:393)
[...]

Thread 14 name:
Thread 14 Crashed:
0   yousician                     	0x0000000104d90e7c core::hash_set<core::pair<core::basic_string<char, core::StringStorageDefault<char> > const, int, true>, core::hash_pair<core::hash<core::basic_string<char, core::StringStorageDefault<char> > >, core::basic_string<char, core::StringStorageDefault<char> > const, int>, core::equal_pair<std::__1::equal_to<core::basic_string<char, core::StringStorageDefault<char> > >, core::basic_string<char, core::StringStorageDefault<char> > const, int> >::node* core::hash_set<core::pair<core::basic_string<char, core::StringStorageDefault<char> > const, int, true>, core::hash_pair<core::hash<core::basic_string<char, core::StringStorageDefault<char> > >, core::basic_string<char, core::StringStorageDefault<char> > const, int>, core::equal_pair<std::__1::equal_to<core::basic_string<char, core::StringStorageDefault<char> > >, core::basic_string<char, core::StringStorageDefault<char> > const, int> >::lookup<core::basic_string<char, core::StringStorageDefault<char> > >(core::basic_string<char, core::StringStorageDefault<char> > const&) const + 68 (hash_set.h:566)
1   yousician                     	0x0000000104d8e260 MonoManager::GetScriptingClass(char const*, char const*, char const*) + 104 (hash_map.h:175)
2   yousician                     	0x00000001049de99c InitializeCoreScriptingClasses() + 104 (CoreScriptingClasses.cpp:25)
3   yousician                     	0x00000001049de910 GetCoreScriptingClassesPtr() + 28 (CoreScriptingClasses.cpp:1439)
4   yousician                     	0x00000001049de80c GetCoreScriptingClasses() + 12 (CoreScriptingClasses.cpp:1448)
5   yousician                     	0x0000000104d8f5c8 Scripting::GetTypeFromScriptingClass(ScriptingClassPtr) + 64 (Scripting.cpp:649)
6   yousician                     	0x0000000104d8f7ac Scripting::FindObjectsOfType(ScriptingSystemTypeObjectPtr, Scripting::FindMode) + 72 (Scripting.cpp:830)
7   yousician                     	0x00000001040817a8 Object_FindObjectOfType_m67275058 + 92 (Bulk_UnityEngine.CoreModule_1.cpp:15603)
8   yousician                     	0x0000000104683488 Object_FindObjectOfType_TisRuntimeObject_m2027585794_gshared + 164 (GenericMethods18.cpp:61551)
9   yousician                     	0x0000000104026e54 MainThreadDispatcher_Initialize_m2166422574 + 152 (Bulk_UniRx_0.cpp:31695)
10  yousician                     	0x0000000104026308 MainThreadDispatcher_get_Instance_m1146637714 + 84 (Bulk_UniRx_0.cpp:31657)
11  yousician                     	0x0000000104026264 MainThreadDispatcher_Post_m2136125861 + 96 (Bulk_UniRx_0.cpp:31126)
12  yousician                     	0x00000001036cd2c0 VEMNcNB_OnNext_m1885355514_gshared + 128 (Bulk_Generics_87.cpp:31104)
13  yousician                     	0x00000001036cd050 VEMNcNB_Run_m3781630758_gshared + 220 (Bulk_Generics_87.cpp:41)
14  yousician                     	0x0000000104373ffc QueueUserWorkItemCallback_WaitCallback_Context_m2238596144 + 120 (Bulk_mscorlib_16.cpp:25710)
15  yousician                     	0x000000010437088c ExecutionContext_RunInternal_m3256186641 + 348 (Bulk_mscorlib_16.cpp:21576)
16  yousician                     	0x000000010436c198 ThreadPoolWorkQueue_Dispatch_m3092487892 + 572 (Bulk_mscorlib_16.cpp:45400)
17  yousician                     	0x00000001048c0ef4 RuntimeInvoker_Boolean_t97287965(void (*)(), MethodInfo const*, void*, void**) + 32 (Il2CppInvokerTable.cpp:113833)
18  yousician                     	0x00000001053a1210 worker_thread(void*) + 492 (ThreadPoolWorkerThread.cpp:252)
19  yousician                     	0x00000001053d71b0 il2cpp::vm::ThreadStart(void*) + 96 (Thread.cpp:666)
20  yousician                     	0x00000001053a2b34 il2cpp::os::Thread::RunWrapper(void*) + 88 (Thread.cpp:168)
21  yousician                     	0x00000001053ab69c il2cpp::os::ThreadImpl::ThreadStartWrapper(void*) + 36 (ThreadImpl.cpp:104)
22  libsystem_pthread.dylib       	0x0000000184b99220 _pthread_body + 272 (pthread.c:740)
23  libsystem_pthread.dylib       	0x0000000184b99110 _pthread_start + 292 (pthread.c:799)
24  libsystem_pthread.dylib       	0x0000000184b97b10 thread_start + 4
```

We managed to fix this by performing the `isQuitting` before attempting to call `FindObjectOfType`. It made the errors disappear in the Editor too.