### PR TITLE
Fix ContinueWith error handling and add regression tests

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Operators/ContinueWith.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ContinueWith.cs
@@ -56,16 +56,19 @@ namespace UniRx.Operators
             {
                 if (seenValue)
                 {
+                    IObservable<TResult> result;
                     try
-	                {
-		                var v = parent.selector(lastValue);
-		                // dispose source subscription
-		                serialDisposable.Disposable = v.Subscribe(observer);
-	                }
-	                catch (Exception error)
-	                {
-		                OnError(error);
-	                }
+                    {
+                        result = parent.selector(lastValue);
+                    }
+                    catch (Exception error)
+                    {
+                        OnError(error);
+                        return;
+                    }
+
+                    // dispose source subscription
+                    serialDisposable.Disposable = result.Subscribe(observer);
                 }
                 else
                 {


### PR DESCRIPTION
It seems that while https://github.com/neuecc/UniRx/pull/312 fixed one issue, it caused a regression in another case.

Essentially, the `try` was covering too much code, and if an exception was thrown and *never caught* from the `v.Subscribe(observer)` call, all the chained operators would already be disposed by the time `OnError(error)` was called. This would cause the error to just go to an `EmptyObserver`, essentially disappearing.

I also added regression tests for both this and the previous issue. I couldn't come up with a nice and simple way of reproducing what the combination of `Empty` and `Single` do, so I just wrapped that in a method.