### PR TITLE
Change AsyncTriggers returned value to UniTask<T>

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncAnimatorTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncAnimatorTrigger.cs
@@ -29,7 +29,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnAnimatorIKAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<int> OnAnimatorIKAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onAnimatorIK, ref onAnimatorIKs, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncBeginDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncBeginDragTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnBeginDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnBeginDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onBeginDrag, ref onBeginDrags, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncCancelTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncCancelTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCancelAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnCancelAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCancel, ref onCancels, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncCollision2DTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncCollision2DTrigger.cs
@@ -32,7 +32,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCollisionEnter2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collision2D> OnCollisionEnter2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCollisionEnter2D, ref onCollisionEnter2Ds, cancellationToken);
         }
@@ -44,7 +44,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCollisionExit2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collision2D> OnCollisionExit2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCollisionExit2D, ref onCollisionExit2Ds, cancellationToken);
         }
@@ -56,7 +56,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCollisionStay2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collision2D> OnCollisionStay2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCollisionStay2D, ref onCollisionStay2Ds, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncCollisionTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncCollisionTrigger.cs
@@ -32,7 +32,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCollisionEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collision> OnCollisionEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCollisionEnter, ref onCollisionEnters, cancellationToken);
         }
@@ -44,7 +44,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCollisionExitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collision> OnCollisionExitAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCollisionExit, ref onCollisionExits, cancellationToken);
         }
@@ -56,7 +56,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCollisionStayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collision> OnCollisionStayAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCollisionStay, ref onCollisionStays, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncDeselectTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncDeselectTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnDeselectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnDeselectAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onDeselect, ref onDeselects, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncDragTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onDrag, ref onDrags, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncDropTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncDropTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnDropAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnDropAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onDrop, ref onDrops, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncEndDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncEndDragTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnEndDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnEndDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onEndDrag, ref onEndDrags, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncEventTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncEventTrigger.cs
@@ -59,7 +59,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnDeselectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnDeselectAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onDeselect, ref onDeselects, cancellationToken);
         }
@@ -71,7 +71,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnMoveAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<AxisEventData> OnMoveAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onMove, ref onMoves, cancellationToken);
         }
@@ -83,7 +83,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerDownAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerDownAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerDown, ref onPointerDowns, cancellationToken);
         }
@@ -95,7 +95,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerEnter, ref onPointerEnters, cancellationToken);
         }
@@ -107,7 +107,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerExitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerExitAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerExit, ref onPointerExits, cancellationToken);
         }
@@ -119,7 +119,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerUpAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerUpAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerUp, ref onPointerUps, cancellationToken);
         }
@@ -131,7 +131,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnSelectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnSelectAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onSelect, ref onSelects, cancellationToken);
         }
@@ -143,7 +143,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerClickAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerClickAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerClick, ref onPointerClicks, cancellationToken);
         }
@@ -155,7 +155,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnSubmitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnSubmitAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onSubmit, ref onSubmits, cancellationToken);
         }
@@ -167,7 +167,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onDrag, ref onDrags, cancellationToken);
         }
@@ -179,7 +179,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnBeginDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnBeginDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onBeginDrag, ref onBeginDrags, cancellationToken);
         }
@@ -191,7 +191,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnEndDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnEndDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onEndDrag, ref onEndDrags, cancellationToken);
         }
@@ -203,7 +203,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnDropAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnDropAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onDrop, ref onDrops, cancellationToken);
         }
@@ -215,7 +215,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnUpdateSelectedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnUpdateSelectedAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onUpdateSelected, ref onUpdateSelecteds, cancellationToken);
         }
@@ -227,7 +227,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnInitializePotentialDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnInitializePotentialDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onInitializePotentialDrag, ref onInitializePotentialDrags, cancellationToken);
         }
@@ -239,7 +239,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnCancelAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnCancelAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onCancel, ref onCancels, cancellationToken);
         }
@@ -251,7 +251,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnScrollAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnScrollAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onScroll, ref onScrolls, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncInitializePotentialDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncInitializePotentialDragTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnInitializePotentialDragAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnInitializePotentialDragAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onInitializePotentialDrag, ref onInitializePotentialDrags, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncJointTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncJointTrigger.cs
@@ -30,7 +30,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnJointBreakAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<float> OnJointBreakAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onJointBreak, ref onJointBreaks, cancellationToken);
         }
@@ -42,7 +42,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnJointBreak2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Joint2D> OnJointBreak2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onJointBreak2D, ref onJointBreak2Ds, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncMoveTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncMoveTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnMoveAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<AxisEventData> OnMoveAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onMove, ref onMoves, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncParticleTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncParticleTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnParticleCollisionAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<GameObject> OnParticleCollisionAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onParticleCollision, ref onParticleCollisions, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerClickTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerClickTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerClickAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerClickAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerClick, ref onPointerClicks, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerDownTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerDownTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerDownAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerDownAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerDown, ref onPointerDowns, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerEnterTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerEnterTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerEnter, ref onPointerEnters, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerExitTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerExitTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerExitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerExitAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerExit, ref onPointerExits, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerUpTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncPointerUpTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnPointerUpAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnPointerUpAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onPointerUp, ref onPointerUps, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncScrollTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncScrollTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnScrollAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<PointerEventData> OnScrollAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onScroll, ref onScrolls, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncSelectTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncSelectTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnSelectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnSelectAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onSelect, ref onSelects, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncSubmitTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncSubmitTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnSubmitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnSubmitAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onSubmit, ref onSubmits, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncTrigger2DTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncTrigger2DTrigger.cs
@@ -32,7 +32,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnTriggerEnter2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collider2D> OnTriggerEnter2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onTriggerEnter2D, ref onTriggerEnter2Ds, cancellationToken);
         }
@@ -44,7 +44,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnTriggerExit2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collider2D> OnTriggerExit2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onTriggerExit2D, ref onTriggerExit2Ds, cancellationToken);
         }
@@ -56,7 +56,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnTriggerStay2DAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collider2D> OnTriggerStay2DAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onTriggerStay2D, ref onTriggerStay2Ds, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncTriggerTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncTriggerTrigger.cs
@@ -32,7 +32,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnTriggerEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collider> OnTriggerEnterAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onTriggerEnter, ref onTriggerEnters, cancellationToken);
         }
@@ -44,7 +44,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnTriggerExitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collider> OnTriggerExitAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onTriggerExit, ref onTriggerExits, cancellationToken);
         }
@@ -56,7 +56,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnTriggerStayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<Collider> OnTriggerStayAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onTriggerStay, ref onTriggerStays, cancellationToken);
         }

--- a/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncUpdateSelectedTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/Async/Triggers/AsyncUpdateSelectedTrigger.cs
@@ -28,7 +28,7 @@ namespace UniRx.Async.Triggers
         }
 
 
-        public UniTask OnUpdateSelectedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public UniTask<BaseEventData> OnUpdateSelectedAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetOrAddPromise(ref onUpdateSelected, ref onUpdateSelecteds, cancellationToken);
         }


### PR DESCRIPTION
Change `AsyncTriggers` returned value to `UniTask<T>`

Example
```cs
using System;
using System.Threading.Tasks;
using UniRx.Async;
using UniRx.Async.Triggers;
using UnityEngine;

class TriggerSample : MonoBehaviour
{
    private void Start()
    {
        WaitForCollisionAsync().Forget();
    }

    private async UniTaskVoid WaitForCollisionAsync()
    {
        var trigger = this.GetAsyncCollisionTrigger();

        var collision = await trigger.OnCollisionEnterAsync(); // <<<<

        Debug.Log(collision.gameObject.name);
    }
}
```