### PR TITLE
Dispose parent in inner observer's OnError

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Operators/Merge.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Merge.cs
@@ -113,7 +113,7 @@ namespace UniRx.Operators
                 {
                     lock (parent.gate)
                     {
-                        try { observer.OnError(error); } finally { Dispose(); };
+                        parent.OnError(error);
                     }
                 }
 
@@ -234,7 +234,7 @@ namespace UniRx.Operators
                 {
                     lock (parent.gate)
                     {
-                        try { observer.OnError(error); } finally { Dispose(); };
+                        parent.OnError(error);
                     }
                 }
 

--- a/Assets/Plugins/UniRx/Scripts/Operators/SelectMany.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SelectMany.cs
@@ -154,7 +154,7 @@ namespace UniRx.Operators
                 {
                     lock (parent.gate)
                     {
-                        try { observer.OnError(error); } finally { Dispose(); };
+                        parent.OnError(error);
                     }
                 }
 
@@ -264,7 +264,7 @@ namespace UniRx.Operators
                 {
                     lock (parent.gate)
                     {
-                        try { observer.OnError(error); } finally { Dispose(); };
+                        parent.OnError(error);
                     }
                 }
 
@@ -607,7 +607,7 @@ namespace UniRx.Operators
                 {
                     lock (parent.gate)
                     {
-                        try { observer.OnError(error); } finally { Dispose(); };
+                        parent.OnError(error);
                     }
                 }
 

--- a/Assets/Plugins/UniRx/Scripts/Operators/Switch.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Switch.cs
@@ -105,7 +105,7 @@ namespace UniRx.Operators
                     {
                         if (parent.latest == id)
                         {
-                            parent.observer.OnError(error);
+                            parent.OnError(error);
                         }
                     }
                 }


### PR DESCRIPTION
this fixes #350 .

Merging operators (Merge, Switch, and SelectMany) doesn't dispose parent subscription when inner subscription calls OnError, and this causes some odd behaviours.
- this is different from other combining operators (Zip, CombineLatest for instance)
- this may send `InvalidOperationException: Disposable is already set` in some conditions
- appending a operator (even AsObservable() ) changes the result

This change let they behave same as other operators.
(for example https://github.com/neuecc/UniRx/blob/master/Assets/Plugins/UniRx/Scripts/Operators/Zip.cs#L135-L141 )