### PR TITLE
fix isRequiredSubscribeOnCurrentThread

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Operators/OperatorObservableBase.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/OperatorObservableBase.cs
@@ -25,7 +25,7 @@ namespace UniRx.Operators
             // does not make the safe observer, it breaks exception durability.
             // var safeObserver = Observer.CreateAutoDetachObserver<T>(observer, subscription);
 
-            if (isRequiredSubscribeOnCurrentThread && Scheduler.IsCurrentThreadSchedulerScheduleRequired)
+            if (isRequiredSubscribeOnCurrentThread || Scheduler.IsCurrentThreadSchedulerScheduleRequired)
             {
                 Scheduler.CurrentThread.Schedule(() => subscription.Disposable = SubscribeCore(observer, subscription));
             }


### PR DESCRIPTION
`isRequiredSubscribeOnCurrentThread` is not working.
`CurrentThreadScheduler` is never used, even if this flag is true.

```cs
Observable.Create<int>(o =>
    {
        o.OnNext(1);
        o.OnCompleted();
        return Disposable.Empty;
    }, isRequiredSubscribeOnCurrentThread: true) // not work
    .Repeat()
    .Take(1)
    .Subscribe(x => Debug.Log(x), () => Debug.Log("Stop"))
    .AddTo(this);
```