### PR TITLE
Fix ReplaySubject InvalidOperationException #292

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Subjects/ReplaySubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/ReplaySubject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UniRx.InternalUtil;
 
 namespace UniRx
@@ -167,7 +168,7 @@ namespace UniRx
 
                 ex = lastError;
                 Trim();
-                foreach (var item in queue)
+                foreach (var item in queue.ToList())
                 {
                     observer.OnNext(item.Value);
                 }

--- a/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
+++ b/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
@@ -6,7 +6,7 @@ using System.Threading;
 namespace UniRx.Tests
 {
     
-    public class SubjectTests
+    public class SubjectTest
     {
         [Test]
         public void Subject()
@@ -401,6 +401,7 @@ namespace UniRx.Tests
             }
         }
 
+        [Test]
         public void ReplaySubjectBufferReplay()
         {
             var subject = new ReplaySubject<int>(bufferSize: 3);
@@ -415,7 +416,7 @@ namespace UniRx.Tests
             subject.OnNext(100);
             subject.OnNext(1000);
             subject.OnNext(10000);
-            onNext.Is(100, 1000, 10000);  // cut 1, 10
+            onNext.Is(1, 10, 100, 1000, 10000);
 
             // replay subscription
             onNext.Clear();
@@ -424,7 +425,7 @@ namespace UniRx.Tests
             onNext.Is(100, 1000, 10000);
 
             subject.OnNext(20000);
-            onNext.Is(1000, 10000, 20000);
+            onNext.Is(100, 1000, 10000, 20000);
 
             subject.OnCompleted();
             onCompletedCallCount.Is(1);

--- a/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
+++ b/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
@@ -477,5 +477,39 @@ namespace UniRx.Tests
             subject.Subscribe(x => onNext.Add(x), x => exception.Add(x), () => onCompletedCallCount++);
             onNext.Is(10000, 2, 20);
         }
+
+        ///<Summary>
+        /// Regression test for previous InvalidOperationException
+        /// UniRx issue <a href="https://github.com/neuecc/UniRx/issues/292">#292</a>
+        ///</Summary>
+        [Test]
+        public void ReplaySubject_Take_GivesCorrectResult()
+        {
+            var subject = new ReplaySubject<int>(1);
+
+            var onNext = new List<int>();
+            
+            subject.OnNext(1);
+
+            var _ = subject
+                .Take(1)
+                .Do(subject.OnNext)
+                .Subscribe(onNext.Add);
+            
+            onNext.Is(1);
+            
+            _.Dispose();
+            onNext.Clear();
+            
+            subject.OnNext(2);
+            subject.OnNext(3);
+            
+            _ = subject
+                .Take(1)
+                .Do(subject.OnNext)
+                .Subscribe(onNext.Add);
+            
+            onNext.Is(3);
+        }
     }
 }


### PR DESCRIPTION
This fixes an InvalidOperationException in certain situations when using ReplaySubject. See #292 

I also fixed a ReplaySubject unit test which was previously disabled and failing due to an incorrect test implementation.