### PR TITLE
OnEnableAsObservable fails to trigger OnNext when component.enabled toggles

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMonoEnableTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMonoEnableTrigger.cs
@@ -1,0 +1,49 @@
+﻿using System; // require keep for Windows Universal App
+using UnityEngine;
+
+namespace UniRx.Triggers
+{
+    [DisallowMultipleComponent]
+    public class ObservableMonoEnableTrigger : ObservableTriggerBase
+    {
+        Subject<Unit> onEnable;
+        Subject<Unit> onDisable;
+        private MonoBehaviour behaviour;
+
+        private void Start()
+        {
+            behaviour.ObserveEveryValueChanged(x => x.enabled).Subscribe(_=>{
+                if (behaviour.enabled && onEnable != null) onEnable.OnNext(Unit.Default);
+            });
+
+            behaviour.ObserveEveryValueChanged(x => !x.enabled).Subscribe(_ => {
+                if (!behaviour.enabled && onDisable != null) onDisable.OnNext(Unit.Default);
+            });
+        }
+        
+        public IObservable<Unit> OnMonoEnableAsObservable(MonoBehaviour behaviour)
+        {
+            this.behaviour = behaviour;
+            return onEnable ?? (onEnable = new Subject<Unit>());
+        }
+        
+        /// <summary>This function is called when the behaviour becomes disabled () or inactive.</summary>
+        public IObservable<Unit> OnMonoDisableAsObservable(MonoBehaviour behaviour)
+        {
+            this.behaviour = behaviour;
+            return onDisable ?? (onDisable = new Subject<Unit>());
+        }
+
+        protected override void RaiseOnCompletedOnDestroy()
+        {
+            if (onEnable != null)
+            {
+                onEnable.OnCompleted();
+            }
+            if (onDisable != null)
+            {
+                onDisable.OnCompleted();
+            }
+        }
+    }
+}

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
@@ -106,6 +106,24 @@ namespace UniRx.Triggers
 
         #endregion
 
+        #region ObservableMonoEnableTrigger
+
+        /// <summary>This function is called when the object becomes enabled and active.</summary>
+        public static IObservable<Unit> OnMonoEnableAsObservable(this MonoBehaviour behaviour)
+        {
+            if (behaviour == null || behaviour.gameObject == null) return Observable.Empty<Unit>();
+            return GetOrAddComponent<ObservableMonoEnableTrigger>(behaviour.gameObject).OnMonoEnableAsObservable(behaviour);
+        }
+
+        /// <summary>This function is called when the behaviour becomes disabled () or inactive.</summary>
+        public static IObservable<Unit> OnMonoDisableAsObservable(this MonoBehaviour behaviour)
+        {
+            if (behaviour == null || behaviour.gameObject == null) return Observable.Empty<Unit>();
+            return GetOrAddComponent<ObservableMonoEnableTrigger>(behaviour.gameObject).OnMonoDisableAsObservable(behaviour);
+        }
+
+        #endregion
+
         #region ObservableFixedUpdateTrigger
 
         /// <summary>This function is called every fixed framerate frame, if the MonoBehaviour is enabled.</summary>


### PR DESCRIPTION
When calling the extension method myMonoBehaviour.OnEnableAsObservable(), subscription only works if you toggle the enabled property of the game object or the trigger, not if you toggle the component. Same is true for OnDisable. This is because ObservableEnableTrigger listens to itself. When the trigger is created by the component extension method, the implication is that it will listen to its creator. Here's a pull request for an alternate version of OnEnableAsObservable() called OnMonoEnableAsObservable(), in which the trigger listens for a change of the enabled property of its creator component, rather than listening for its own OnEnable method.