### PR TITLE
Update ReactiveDictionary.cs

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveDictionary.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveDictionary.cs
@@ -123,6 +123,11 @@ namespace UniRx
         [UnityEngine.SerializeField]
 #endif
         readonly Dictionary<TKey, TValue> inner;
+        
+        public bool IsNull()
+        {
+            return inner == null;
+        }
 
         public ReactiveDictionary()
         {


### PR DESCRIPTION
If "inner" is null, it cannot be detected.
If passing null dictionary as a parameter, get a fake null check.
![화면 캡처 2020-10-19 181101](https://user-images.githubusercontent.com/6531761/96425518-1339fa00-1237-11eb-8123-5551f5798aa8.png)

If I using it incorrectly,  ignore this request.
