### PR TITLE
Support "Domain Reload" disabled in a project

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -437,6 +437,17 @@ namespace UniRx
             }
         }
 
+#if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
+        // Clean up static properties for times when Domain Reload is disabled.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void DomainCleanup()
+        {
+            initialized = false;
+            isQuitting = false;
+            instance = null;
+        }
+#endif
+
         public static void Initialize()
         {
             if (!initialized)

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
@@ -38,8 +38,13 @@ namespace UniRx
             }
         }
 
+#if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
+        // This callback is notified when Unity initializes subsystems
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#else
         // This callback is notified after scripts have been reloaded.
         [DidReloadScripts]
+#endif
         public static void OnDidReloadScripts()
         {
             // Filter DidReloadScripts callbacks to the moment where playmodeState transitions into isPlaying.


### PR DESCRIPTION
Some statics maintain their values when "Domain Reload" is disabled in a project.  This pull request helps clean stale values when the game is started in editor.