### PR TITLE
Add version defines to UniRx.asmdef

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
+++ b/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
@@ -25,6 +25,11 @@
             "define": "UNIRX_PHYSICS2D_SUPPORT"
         },
         {
+            "name": "com.unity.modules.unitywebrequestwww",
+            "expression": "",
+            "define": "UNIRX_WWW_SUPPORT"
+        },
+        {
             "name": "com.unity.ugui",
             "expression": "",
             "define": "UNIRX_UGUI_SUPPORT"

--- a/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
+++ b/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
@@ -8,5 +8,11 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "UNIRX_UGUI_SUPPORT"
+        }
+    ]
 }

--- a/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
+++ b/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
@@ -10,6 +10,11 @@
     "defineConstraints": [],
     "versionDefines": [
         {
+            "name": "com.unity.modules.animation",
+            "expression": "",
+            "define": "UNIRX_ANIMATION_SUPPORT"
+        },
+        {
             "name": "com.unity.ugui",
             "expression": "",
             "define": "UNIRX_UGUI_SUPPORT"

--- a/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
+++ b/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
@@ -15,6 +15,11 @@
             "define": "UNIRX_ANIMATION_SUPPORT"
         },
         {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "UNIRX_PHYSICS_SUPPORT"
+        },
+        {
             "name": "com.unity.ugui",
             "expression": "",
             "define": "UNIRX_UGUI_SUPPORT"

--- a/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
+++ b/Assets/Plugins/UniRx/Scripts/UniRx.asmdef
@@ -20,6 +20,11 @@
             "define": "UNIRX_PHYSICS_SUPPORT"
         },
         {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "UNIRX_PHYSICS2D_SUPPORT"
+        },
+        {
             "name": "com.unity.ugui",
             "expression": "",
             "define": "UNIRX_UGUI_SUPPORT"

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -117,6 +117,7 @@ namespace UniRx
                     }
 
                     var type = current.GetType();
+#if !UNITY_2019_1_OR_NEWER || UNIRX_WWW_SUPPORT
 #if UNITY_2018_3_OR_NEWER
 #pragma warning disable CS0618
 #endif
@@ -126,10 +127,12 @@ namespace UniRx
                         editorQueueWorker.Enqueue(_ => ConsumeEnumerator(UnwrapWaitWWW(www, routine)), null);
                         return;
                     }
+                    else
 #if UNITY_2018_3_OR_NEWER
 #pragma warning restore CS0618
 #endif
-                    else if (type == typeof(AsyncOperation))
+#endif
+                    if (type == typeof(AsyncOperation))
                     {
                         var asyncOperation = (AsyncOperation)current;
                         editorQueueWorker.Enqueue(_ => ConsumeEnumerator(UnwrapWaitAsyncOperation(asyncOperation, routine)), null);
@@ -162,6 +165,7 @@ namespace UniRx
                 }
             }
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_WWW_SUPPORT
 #if UNITY_2018_3_OR_NEWER
 #pragma warning disable CS0618
 #endif
@@ -175,6 +179,7 @@ namespace UniRx
             }
 #if UNITY_2018_3_OR_NEWER
 #pragma warning restore CS0618
+#endif
 #endif
 
             IEnumerator UnwrapWaitAsyncOperation(AsyncOperation asyncOperation, IEnumerator continuation)

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
@@ -229,12 +229,14 @@ namespace UniRx
     {
         readonly static HashSet<Type> YieldInstructionTypes = new HashSet<Type>
         {
+            #if !UNITY_2019_1_OR_NEWER || UNIRX_WWW_SUPPORT
             #if UNITY_2018_3_OR_NEWER
 #pragma warning disable CS0618
 #endif
             typeof(WWW),
             #if UNITY_2018_3_OR_NEWER
 #pragma warning restore CS0618
+#endif
 #endif
             typeof(WaitForEndOfFrame),
             typeof(WaitForFixedUpdate),

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
@@ -1,3 +1,5 @@
+#if !UNITY_2019_1_OR_NEWER || UNIRX_WWW_SUPPORT
+
 using System;
 using System.Collections;
 using UnityEngine;
@@ -16,10 +18,10 @@ namespace UniRx
 #if !(UNITY_METRO || UNITY_WP8) && (UNITY_4_4 || UNITY_4_3 || UNITY_4_2 || UNITY_4_1 || UNITY_4_0_1 || UNITY_4_0 || UNITY_3_5 || UNITY_3_4 || UNITY_3_3 || UNITY_3_2 || UNITY_3_1 || UNITY_3_0_0 || UNITY_3_0 || UNITY_2_6_1 || UNITY_2_6)
     // Fallback for Unity versions below 4.5
     using Hash = System.Collections.Hashtable;
-    using HashEntry = System.Collections.DictionaryEntry;    
+    using HashEntry = System.Collections.DictionaryEntry;
 #else
-    // Unity 4.5 release notes: 
-    // WWW: deprecated 'WWW(string url, byte[] postData, Hashtable headers)', 
+    // Unity 4.5 release notes:
+    // WWW: deprecated 'WWW(string url, byte[] postData, Hashtable headers)',
     // use 'public WWW(string url, byte[] postData, Dictionary<string, string> headers)' instead.
     using Hash = System.Collections.Generic.Dictionary<string, string>;
     using HashEntry = System.Collections.Generic.KeyValuePair<string, string>;
@@ -408,7 +410,7 @@ namespace UniRx
             this.RawErrorMessage = www.error;
             this.ResponseHeaders = www.responseHeaders;
             this.HasResponse = false;
-            this.Text = text; 
+            this.Text = text;
 
             var splitted = RawErrorMessage.Split(' ', ':');
             if (splitted.Length != 0)
@@ -439,4 +441,6 @@ namespace UniRx
 
 #if UNITY_2018_3_OR_NEWER
 #pragma warning restore CS0618
+#endif
+
 #endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveCommand.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveCommand.cs
@@ -359,7 +359,7 @@ namespace UniRx
 #if !UniRxLibrary
 
         // for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
         /// <summary>
         /// Bind ReactiveCommand to button's interactable and onClick.
@@ -440,7 +440,7 @@ namespace UniRx
 #if !UniRxLibrary
 
         // for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
         /// <summary>
         /// Bind AsyncRaectiveCommand to button's interactable and onClick.

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableAnimatorTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableAnimatorTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System; // require keep for Windows Universal App
+﻿#if !UNITY_2019_1_OR_NEWER || UNIRX_ANIMATION_SUPPORT
+
+using System; // require keep for Windows Universal App
 using UnityEngine;
 
 namespace UniRx.Triggers
@@ -47,3 +49,5 @@ namespace UniRx.Triggers
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableBeginDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableBeginDragTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCancelTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCancelTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollision2DTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollision2DTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System; // require keep for Windows Universal App
+﻿#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS2D_SUPPORT
+
+using System; // require keep for Windows Universal App
 using UnityEngine;
 
 namespace UniRx.Triggers
@@ -65,3 +67,5 @@ namespace UniRx.Triggers
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollisionTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollisionTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System; // require keep for Windows Universal App
+﻿#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
+using System; // require keep for Windows Universal App
 using UnityEngine;
 
 namespace UniRx.Triggers
@@ -65,3 +67,5 @@ namespace UniRx.Triggers
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDeselectTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDeselectTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDragTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDropTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDropTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEndDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEndDragTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEventTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEventTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableInitializePotentialDragTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableInitializePotentialDragTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableJointTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableJointTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System; // require keep for Windows Universal App
+﻿#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
+using System; // require keep for Windows Universal App
 using UnityEngine;
 
 namespace UniRx.Triggers
@@ -17,8 +19,8 @@ namespace UniRx.Triggers
         {
             return onJointBreak ?? (onJointBreak = new Subject<float>());
         }
-        
-        
+
+
         Subject<Joint2D> onJointBreak2D;
 
         void OnJointBreak2D(Joint2D brokenJoint)
@@ -30,7 +32,7 @@ namespace UniRx.Triggers
         {
             return onJointBreak2D ?? (onJointBreak2D = new Subject<Joint2D>());
         }
-        
+
 
         protected override void RaiseOnCompletedOnDestroy()
         {
@@ -45,3 +47,5 @@ namespace UniRx.Triggers
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMoveTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMoveTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerClickTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerClickTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerDownTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerDownTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerEnterTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerEnterTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerExitTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerExitTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerUpTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerUpTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableScrollTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableScrollTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSelectTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSelectTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableStateMachineTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableStateMachineTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// over Unity5 added StateMachineBehaviour
-#if !(UNITY_4_7 || UNITY_4_6 || UNITY_4_5 || UNITY_4_4 || UNITY_4_3 || UNITY_4_2 || UNITY_4_1 || UNITY_4_0_1 || UNITY_4_0 || UNITY_3_5 || UNITY_3_4 || UNITY_3_3 || UNITY_3_2 || UNITY_3_1 || UNITY_3_0_0 || UNITY_3_0 || UNITY_2_6_1 || UNITY_2_6)
+#if !(UNITY_4_7 || UNITY_4_6 || UNITY_4_5 || UNITY_4_4 || UNITY_4_3 || UNITY_4_2 || UNITY_4_1 || UNITY_4_0_1 || UNITY_4_0 || UNITY_3_5 || UNITY_3_4 || UNITY_3_3 || UNITY_3_2 || UNITY_3_1 || UNITY_3_0_0 || UNITY_3_0 || UNITY_2_6_1 || UNITY_2_6) && (!UNITY_2019_1_OR_NEWER || UNIRX_ANIMATION_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSubmitTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSubmitTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTrigger2DTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTrigger2DTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System; // require keep for Windows Universal App
+﻿#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS2D_SUPPORT
+
+using System; // require keep for Windows Universal App
 using UnityEngine;
 
 namespace UniRx.Triggers
@@ -65,3 +67,5 @@ namespace UniRx.Triggers
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
@@ -1,7 +1,7 @@
 ﻿using System; // require keep for Windows Universal App
 using UnityEngine;
 
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 using UnityEngine.EventSystems;
 #endif
 
@@ -326,6 +326,7 @@ namespace UniRx.Triggers
 
         #endregion
 
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
         // uGUI
 
         #region ObservableEventTrigger classes
@@ -433,6 +434,7 @@ namespace UniRx.Triggers
         }
 
         #endregion
+#endif
 
 #endif
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
@@ -10,6 +10,9 @@ namespace UniRx.Triggers
     // for Component
     public static partial class ObservableTriggerExtensions
     {
+
+#if !UNITY_2019_1_OR_NEWER || UNIRX_ANIMATION_SUPPORT
+
         #region ObservableAnimatorTrigger
 
         /// <summary>Callback for setting up animation IK (inverse kinematics).</summary>
@@ -27,6 +30,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
         #region ObservableCollision2DTrigger
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
@@ -59,6 +59,8 @@ namespace UniRx.Triggers
 
         #endregion
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
         #region ObservableCollisionTrigger
 
         /// <summary>OnCollisionEnter is called when this collider/rigidbody has begun touching another rigidbody/collider.</summary>
@@ -84,6 +86,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
         #region ObservableDestroyTrigger
 
@@ -220,6 +224,8 @@ namespace UniRx.Triggers
 
         #endregion
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
         #region ObservableTriggerTrigger
 
         /// <summary>OnTriggerEnter is called when the Collider other enters the trigger.</summary>
@@ -245,6 +251,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
         #region ObservableUpdateTrigger
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs
@@ -33,6 +33,8 @@ namespace UniRx.Triggers
 
 #endif
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS2D_SUPPORT
+
         #region ObservableCollision2DTrigger
 
         /// <summary>Sent when an incoming collider makes contact with this object's collider (2D physics only).</summary>
@@ -58,6 +60,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
 #if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
 
@@ -198,6 +202,8 @@ namespace UniRx.Triggers
 
 #endif
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS2D_SUPPORT
+
         #region ObservableTrigger2DTrigger
 
         /// <summary>Sent when another object enters a trigger collider attached to this object (2D physics only).</summary>
@@ -223,6 +229,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
 #if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
@@ -6,6 +6,9 @@ namespace UniRx.Triggers
     // for GameObject
     public static partial class ObservableTriggerExtensions
     {
+
+#if !UNITY_2019_1_OR_NEWER || UNIRX_ANIMATION_SUPPORT
+
         #region ObservableAnimatorTrigger
 
         /// <summary>Callback for setting up animation IK (inverse kinematics).</summary>
@@ -23,6 +26,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
         #region ObservableCollision2DTrigger
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
@@ -55,6 +55,8 @@ namespace UniRx.Triggers
 
         #endregion
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
         #region ObservableCollisionTrigger
 
         /// <summary>OnCollisionEnter is called when this collider/rigidbody has begun touching another rigidbody/collider.</summary>
@@ -80,6 +82,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
         #region ObservableDestroyTrigger
 
@@ -216,6 +220,8 @@ namespace UniRx.Triggers
 
         #endregion
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
         #region ObservableTriggerTrigger
 
         /// <summary>OnTriggerEnter is called when the Collider other enters the trigger.</summary>
@@ -241,6 +247,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
         #region ObservableUpdateTrigger
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs
@@ -29,6 +29,8 @@ namespace UniRx.Triggers
 
 #endif
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS2D_SUPPORT
+
         #region ObservableCollision2DTrigger
 
         /// <summary>Sent when an incoming collider makes contact with this object's collider (2D physics only).</summary>
@@ -54,6 +56,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
 #if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
 
@@ -194,6 +198,8 @@ namespace UniRx.Triggers
 
 #endif
 
+#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS2D_SUPPORT
+
         #region ObservableTrigger2DTrigger
 
         /// <summary>Sent when another object enters a trigger collider attached to this object (2D physics only).</summary>
@@ -219,6 +225,8 @@ namespace UniRx.Triggers
         }
 
         #endregion
+
+#endif
 
 #if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System; // require keep for Windows Universal App
+﻿#if !UNITY_2019_1_OR_NEWER || UNIRX_PHYSICS_SUPPORT
+
+using System; // require keep for Windows Universal App
 using UnityEngine;
 
 namespace UniRx.Triggers
@@ -47,7 +49,7 @@ namespace UniRx.Triggers
         {
             return onTriggerStay ?? (onTriggerStay = new Subject<Collider>());
         }
-        
+
         protected override void RaiseOnCompletedOnDestroy()
         {
             if (onTriggerEnter != null)
@@ -65,3 +67,5 @@ namespace UniRx.Triggers
         }
     }
 }
+
+#endif

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableUpdateSelectedTrigger.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableUpdateSelectedTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System; // require keep for Windows Universal App
 using UnityEngine;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityGraphicExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityGraphicExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System;
 using UnityEngine.Events;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityUIComponentExtensions.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityUIComponentExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// for uGUI(from 4.6)
-#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5)
+#if !(UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5) && (!UNITY_2019_1_OR_NEWER || UNIRX_UGUI_SUPPORT)
 
 using System;
 using UnityEngine;


### PR DESCRIPTION
Added `versionDefines` like [UniTask.asmdef](https://github.com/Cysharp/UniTask/blob/b660506e314f7bae6c6d7e0a927bf768412586ed/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.asmdef#L12-L43). so that it can compile properly depending on the installed packages.