### PR TITLE
Add com.unity.modules.imgui to package dependencies

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/package.json
+++ b/Assets/Plugins/UniRx/Scripts/package.json
@@ -1,9 +1,11 @@
 {
-    "name": "com.neuecc.unirx",
-    "displayName": "UniRx",
-    "version": "7.1.0",
-    "unity": "2018.3",
-    "description": "Reactive Extensions for Unity",
-    "license": "MIT",
-    "dependencies": {}
+  "name": "com.neuecc.unirx",
+  "displayName": "UniRx",
+  "version": "7.1.0",
+  "unity": "2018.3",
+  "description": "Reactive Extensions for Unity",
+  "license": "MIT",
+  "dependencies": {
+    "com.unity.modules.imgui": "1.0.0"
+  }
 }


### PR DESCRIPTION
The current version requires IMGUI in `InspectorDisplayDrawer`, so I added it as a package dependency.