### PR TITLE
fix ScenePlaybackDetector.IsPlaying is still false when disable Domain Reloading

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -669,6 +669,12 @@ namespace UniRx
 
         Subject<Unit> onApplicationQuit;
 
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        public static void OnRuntimeInitializeOnLoadMethod()
+        {
+            isQuitting = false;
+        }
+
         void OnApplicationQuit()
         {
             isQuitting = true;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
@@ -38,6 +38,15 @@ namespace UniRx
             }
         }
 
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        public static void OnRuntimeInitializeOnLoadMethod()
+        {
+            if (AboutToStartScene)
+            {
+                IsPlaying = true;
+            }
+        }
+
         // This callback is notified after scripts have been reloaded.
         [DidReloadScripts]
         public static void OnDidReloadScripts()
@@ -54,9 +63,23 @@ namespace UniRx
         {
 #if UNITY_2017_2_OR_NEWER
             EditorApplication.playModeStateChanged += e =>
+            {
+                if (e == PlayModeStateChange.ExitingEditMode)
+                {
+                    AboutToStartScene = true;
+                }
+                else
+                {
+                    AboutToStartScene = false;
+                }
+
+                if (e == PlayModeStateChange.ExitingPlayMode)
+                {
+                    IsPlaying = false;
+                }
+            };
 #else
             EditorApplication.playmodeStateChanged += () =>
-#endif
             {
                 // Before scene start:          isPlayingOrWillChangePlaymode = false;  isPlaying = false
                 // Pressed Playback button:     isPlayingOrWillChangePlaymode = true;   isPlaying = false
@@ -77,6 +100,7 @@ namespace UniRx
                     IsPlaying = false;
                 }
             };
+#endif
         }
     }
 }


### PR DESCRIPTION
fix #490

When I checked, ScenePlaybackDetector.IsPlaying is still false even though it was playing.