### PR TITLE
Fix typo (`3 second` -> `3 seconds`)

### DIFF
--- a/Assets/Plugins/UniRx/Examples/Sample02_ObservableTriggers.cs
+++ b/Assets/Plugins/UniRx/Examples/Sample02_ObservableTriggers.cs
@@ -17,7 +17,7 @@ namespace UniRx.Examples
                 .SampleFrame(30)
                 .Subscribe(x => Debug.Log("cube"), () => Debug.Log("destroy"));
 
-            // destroy after 3 second:)
+            // destroy after 3 seconds :)
             GameObject.Destroy(cube, 3f);
         }
     }


### PR DESCRIPTION
Also added newline on the end of file (automatically added by GitHub)