### PR TITLE
Fix a typo in readme for Adventure Capitalist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,7 +1228,7 @@ Intro slide by [@torisoup](https://github.com/torisoup)
 
 Intro slide and sample game by [@Xerios](https://github.com/Xerios)
 
-* [GDC 2016 Sessions of Adventure Capialist](https://www.youtube.com/watch?v=j3YhG91mPsU&feature=youtu.be&t=9m12s)
+* [Adventure Capitalist Postmortem (GDC 2016)](https://www.youtube.com/watch?v=j3YhG91mPsU&feature=youtu.be&t=9m12s)
 
 How to integrate with PlayFab API
 


### PR DESCRIPTION
Used video title for the link.

`Capialist` 😅 