### PR TITLE
Consume enumerators for types inheriting AsyncOperation.

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -129,7 +129,7 @@ namespace UniRx
 #if UNITY_2018_3_OR_NEWER
 #pragma warning restore CS0618
 #endif
-                    else if (type == typeof(AsyncOperation))
+                    else if (typeof(AsyncOperation).IsAssignableFrom(type))
                     {
                         var asyncOperation = (AsyncOperation)current;
                         editorQueueWorker.Enqueue(_ => ConsumeEnumerator(UnwrapWaitAsyncOperation(asyncOperation, routine)), null);


### PR DESCRIPTION
## Problem

Enumerators for the types inheriting `AsyncOperation` are not consumed as expected. All `AsyncOperation`s have `isDone` property that needs to be checked before completing the enumeration. This is done correctly for the base type by using the `Unwrap...` method, but the types inheriting it are handled as an unkown case.

## Example

Without this fix, when a webrequest is performed in Edit-mode using `UnityWebRequest.Get()` and `AsAsyncOperationObservable` extension, the observable publishes a value immediately without waiting request to complete.

## Solution

Changed comparison to handle all types assignable from the `AsyncOperation` base class, so the completion is waited for them before publishing a value.