### PR TITLE
Fix: When domain reload disabled dispatchers doesnt work as expected.…

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using UniRx.InternalUtil;
+using UnityEditor;
 using UnityEngine;
 
 namespace UniRx
@@ -407,6 +408,14 @@ namespace UniRx
         static MainThreadDispatcher instance;
         static bool initialized;
         static bool isQuitting = false;
+
+#if UNITY_EDITOR
+        [InitializeOnEnterPlayMode]
+        private static void OnEnterPlayMode()
+        {
+            isQuitting = false;
+        }
+#endif
 
         public static string InstanceName
         {

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using UnityEditor;
 using UnityEngine;
 
 namespace UniRx
@@ -20,6 +21,17 @@ namespace UniRx
             Scheduler.DefaultSchedulers.Iteration = Scheduler.CurrentThread;
             Scheduler.DefaultSchedulers.TimeBasedOperations = MainThread;
             Scheduler.DefaultSchedulers.AsyncConversions = Scheduler.ThreadPool;
+        }
+#endif
+
+#if UNITY_EDITOR
+        [InitializeOnEnterPlayMode]
+        private static void OnEnterPlayMode()
+        {
+            mainThread = null;
+            mainThreadIgnoreTimeScale = null;
+            mainThreadEndOfFrame = null;
+            mainThreadFixedUpdate = null;
         }
 #endif
         static IScheduler mainThread;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
@@ -1,8 +1,6 @@
 #if UNITY_EDITOR
 
 using UnityEditor;
-using UnityEditor.Callbacks;
-using UnityEngine;
 
 namespace UniRx
 {
@@ -11,25 +9,11 @@ namespace UniRx
     {
         private static bool _isPlaying = false;
 
-        private static bool AboutToStartScene
-        {
-            get
-            {
-                return EditorPrefs.GetBool("AboutToStartScene");
-            }
-            set
-            {
-                EditorPrefs.SetBool("AboutToStartScene", value);
-            }
-        }
 
         public static bool IsPlaying
         {
-            get
-            {
-                return _isPlaying;
-            }
-            set
+            get => _isPlaying;
+            private set
             {
                 if (_isPlaying != value)
                 {
@@ -38,15 +22,11 @@ namespace UniRx
             }
         }
 
-        // This callback is notified after scripts have been reloaded.
-        [DidReloadScripts]
-        public static void OnDidReloadScripts()
+
+        [InitializeOnEnterPlayMode]
+        public static void OnDidReloadScriptsA()
         {
-            // Filter DidReloadScripts callbacks to the moment where playmodeState transitions into isPlaying.
-            if (AboutToStartScene)
-            {
-                IsPlaying = true;
-            }
+            IsPlaying = true;
         }
 
         // InitializeOnLoad ensures that this constructor is called when the Unity Editor is started.
@@ -62,16 +42,7 @@ namespace UniRx
                 // Pressed Playback button:     isPlayingOrWillChangePlaymode = true;   isPlaying = false
                 // Playing:                     isPlayingOrWillChangePlaymode = false;  isPlaying = true
                 // Pressed stop button:         isPlayingOrWillChangePlaymode = true;   isPlaying = true
-                if (EditorApplication.isPlayingOrWillChangePlaymode && !EditorApplication.isPlaying)
-                {
-                    AboutToStartScene = true;
-                }
-                else
-                {
-                    AboutToStartScene = false;
-                }
 
-                // Detect when playback is stopped.
                 if (!EditorApplication.isPlaying)
                 {
                     IsPlaying = false;


### PR DESCRIPTION
If the domain reload is disabled, it does not reset some data. Thus it doesnt  create MainThreadDispatcher on the scene, and its executes actions on EditorThreadDispatcher. Therefore unirx api works unexpectedly.

* This situation only affects the editor and provides a solution for the editor.
#fix https://github.com/neuecc/UniRx/issues/520